### PR TITLE
include: Automatically include videodev2_exynos_media_ext.h

### DIFF
--- a/include/linux/videodev2_exynos_media.h
+++ b/include/linux/videodev2_exynos_media.h
@@ -12,6 +12,8 @@
  * published by the Free Software Foundation.
  */
 
+#include <linux/videodev2_exynos_media_ext.h>
+
 #ifndef __LINUX_VIDEODEV2_EXYNOS_MEDIA_H
 #define __LINUX_VIDEODEV2_EXYNOS_MEDIA_H
 


### PR DESCRIPTION
- libvideocodec requires definitions that the current include
  doesn't have. Therefore, include videodev2_exynos_media_ext.h
  from videodev2_exynos_media.h, which libvideocodec includes

Signed-off-by: Paul Keith javelinanddart@gmail.com
